### PR TITLE
fix tenant when updating existing Azure Credential

### DIFF
--- a/src/main/java/com/microsoft/azure/util/AzureCredentials.java
+++ b/src/main/java/com/microsoft/azure/util/AzureCredentials.java
@@ -140,7 +140,7 @@ public class AzureCredentials extends BaseStandardCredentials {
             this.clientSecret = Secret.fromString(clientSecret);
             this.oauth2TokenEndpoint = Secret.fromString(oauth2TokenEndpoint);
             this.tenant = Secret.fromString(
-                    ServicePrincipal.getTenantFromTokenEndpoint(oauth2TokenEndpoint));
+                    ServicePrincipal.getTenantFromTokenEndpoint(this.oauth2TokenEndpoint.getPlainText()));
 
             if (StringUtils.isBlank(serviceManagementURL)) {
                 this.serviceManagementURL = Constants.DEFAULT_MANAGEMENT_URL;

--- a/src/main/java/com/microsoft/azure/util/AzureCredentials.java
+++ b/src/main/java/com/microsoft/azure/util/AzureCredentials.java
@@ -139,8 +139,8 @@ public class AzureCredentials extends BaseStandardCredentials {
             this.clientId = Secret.fromString(clientId);
             this.clientSecret = Secret.fromString(clientSecret);
             this.oauth2TokenEndpoint = Secret.fromString(oauth2TokenEndpoint);
-            this.tenant = Secret.fromString(
-                    ServicePrincipal.getTenantFromTokenEndpoint(this.oauth2TokenEndpoint.getPlainText()));
+            this.tenant = Secret.fromString(ServicePrincipal.getTenantFromTokenEndpoint(
+                    this.oauth2TokenEndpoint.getPlainText()));
 
             if (StringUtils.isBlank(serviceManagementURL)) {
                 this.serviceManagementURL = Constants.DEFAULT_MANAGEMENT_URL;


### PR DESCRIPTION
fix issue: the parameter `oauth2TokenEndpoint` is base64-encoded so the `ServicePrincipal.getTenantFromTokenEndpoint` always fails to get the right tenantId. Empty string got in fact.  Replace with the decoded text to fix it.