### PR TITLE
Improve Azure credential creation

### DIFF
--- a/src/main/java/com/microsoft/azure/util/AzureCredentials.java
+++ b/src/main/java/com/microsoft/azure/util/AzureCredentials.java
@@ -44,7 +44,7 @@ public class AzureCredentials extends BaseStandardCredentials {
         public static final String DEFAULT_GRAPH_ENDPOINT
                 = "https://graph.windows.net/";
         public static final String DEFAULT_OAUTH_PREFIX
-                = "https://login.windows.net/";
+                = "https://login.windows.net/<TenantId>";
     }
 
     public static class ServicePrincipal implements java.io.Serializable {

--- a/src/main/java/com/microsoft/azure/util/AzureCredentials.java
+++ b/src/main/java/com/microsoft/azure/util/AzureCredentials.java
@@ -43,6 +43,8 @@ public class AzureCredentials extends BaseStandardCredentials {
                 = "https://management.azure.com/";
         public static final String DEFAULT_GRAPH_ENDPOINT
                 = "https://graph.windows.net/";
+        public static final String DEFAULT_OAUTH_PREFIX
+                = "https://login.windows.net/";
     }
 
     public static class ServicePrincipal implements java.io.Serializable {
@@ -340,6 +342,10 @@ public class AzureCredentials extends BaseStandardCredentials {
 
         public final String getDefaultGraphEndpoint() {
             return Constants.DEFAULT_GRAPH_ENDPOINT;
+        }
+
+        public final String getDefaultOAuthPrefix() {
+            return Constants.DEFAULT_OAUTH_PREFIX;
         }
 
         public final FormValidation doVerifyConfiguration(

--- a/src/main/java/com/microsoft/azure/util/AzureCredentials.java
+++ b/src/main/java/com/microsoft/azure/util/AzureCredentials.java
@@ -287,11 +287,11 @@ public class AzureCredentials extends BaseStandardCredentials {
     }
 
     public final String getSubscriptionId() {
-        return data.subscriptionId.getEncryptedValue();
+        return data.subscriptionId.getPlainText();
     }
 
     public final String getClientId() {
-        return data.clientId.getEncryptedValue();
+        return data.clientId.getPlainText();
     }
 
     public final String getClientSecret() {
@@ -299,7 +299,7 @@ public class AzureCredentials extends BaseStandardCredentials {
     }
 
     public final String getOauth2TokenEndpoint() {
-        return data.oauth2TokenEndpoint.getEncryptedValue();
+        return data.oauth2TokenEndpoint.getPlainText();
     }
 
     public final String getServiceManagementURL() {

--- a/src/main/resources/com/microsoft/azure/util/AzureCredentials/credentials.jelly
+++ b/src/main/resources/com/microsoft/azure/util/AzureCredentials/credentials.jelly
@@ -4,17 +4,17 @@
     <j:set var="uniqueId" value="${h.generateId()}"/>
     <f:entry title="${%SubscriptionID}" field="subscriptionId"
              help="/plugin/azure-credentials/help-subscriptionId.html">
-        <f:password/>
+        <f:textbox/>
     </f:entry>
     <f:entry title="${%ClientID}" field="clientId" help="/plugin/azure-credentials/help-clientId.html">
-        <f:password/>
+        <f:textbox/>
     </f:entry>
     <f:entry title="${%ClientSecret}" field="clientSecret" help="/plugin/azure-credentials/help-clientSecret.html">
         <f:password/>
     </f:entry>
     <f:entry title="${%OAuthToken}" field="oauth2TokenEndpoint"
              help="/plugin/azure-credentials/help-oauth2TokenEndpoint.html">
-        <f:password/>
+        <f:textbox default="${descriptor.getDefaultOAuthPrefix()}"/>
     </f:entry>
 
     <f:advanced>


### PR DESCRIPTION
- Change some blanks from password to plain text to avoid mistake copying/typing

- Although prefix in the OAuth is not used in code, as comments said, we keep it for backwards compatibility, and add default prefix to void concatenating by user