### PR TITLE
Disable plugin first class loader and clean dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@
         <jenkins.version>1.625.3</jenkins.version>
         <java.level>7</java.level>
         <jenkins-test-harness.version>2.13</jenkins-test-harness.version>
+        
         <azuresdk.version>1.3.0</azuresdk.version>
         <azure-keyvault.version>1.0.0</azure-keyvault.version>
     </properties>
@@ -90,27 +91,12 @@
             <artifactId>structs</artifactId>
             <version>1.5</version>
         </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.main</groupId>
-            <artifactId>jenkins-test-harness</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <repositories>
         <repository>
             <id>repo.jenkins-ci.org</id>
             <url>https://repo.jenkins-ci.org/public/</url>
-        </repository>
-        <repository>
-            <id>com.springsource.repository.bundles.release</id>
-            <name>SpringSource Enterprise Bundle Repository - SpringSource Bundle Releases</name>
-            <url>http://repository.springsource.com/maven/bundles/release</url>
-        </repository>
-        <repository>
-            <id>com.springsource.repository.bundles.external</id>
-            <name>SpringSource Enterprise Bundle Repository - External Bundle Releases</name>
-            <url>http://repository.springsource.com/maven/bundles/external</url>
         </repository>
     </repositories>
 
@@ -147,10 +133,7 @@
                 <groupId>org.jenkins-ci.tools</groupId>
                 <artifactId>maven-hpi-plugin</artifactId>
                 <configuration>
-                    <pluginFirstClassLoader>true</pluginFirstClassLoader>
                     <maskClasses>
-                        com.microsoft.azure.credentials.
-                        com.microsoft.azure.management.
                         com.google.common.
                     </maskClasses>
                 </configuration>

--- a/src/main/java/com/microsoft/azure/util/AzureCredentials.java
+++ b/src/main/java/com/microsoft/azure/util/AzureCredentials.java
@@ -153,7 +153,7 @@ public class AzureCredentials extends BaseStandardCredentials {
             }
         }
 
-        String getAzureEnvironmentName() {
+        public String getAzureEnvironmentName() {
             return azureEnvironmentName;
         }
 
@@ -499,7 +499,15 @@ public class AzureCredentials extends BaseStandardCredentials {
         this.data.setOauth2TokenEndpoint(oauth2TokenEndpoint);
     }
 
+    /**
+     * typo.
+     */
+    @Deprecated
     public String getAzureEnvionmentName() {
+        return data.getAzureEnvironmentName();
+    }
+
+    public String getAzureEnvironmentName() {
         return data.getAzureEnvironmentName();
     }
 


### PR DESCRIPTION
As a dependency for other plugins, the `PluginFirstClassLoader` in `azure-credentials` may cause problem when we build jobs through JNLP on slave nodes.

We may encounter the `NoClassDefFoundError` under the following conditions:

* Jenkins version is under 2.65 (inclusive), confirmed that 1.651.3 was affected too
   For these versions, the `PluginFirstClassLoader#findResource` inherited from `ClassLoader` always returns `null`
* `azure-credentials` plugin is built with `pluginFirstClassLoader=true`, which is the current state
* When the JNLP slave deserialize the an object (our `MasterToSlaveAction`) which has a field with the type defined in `azure-credentials` (e.g., `AzureCredentials$ServicePrincipal`), it will:
   1. Start an asynchronous job to cache the involved jars from master to slave under (~/.jenkins/cache)
   2. Resolve the class from cache if it is ready, or else fallback to fetch the class binary definition from master
      * If it falls into the fallback process, i.e., the jar cache is not ready before the class loading, PluginFirstClassLoader#findResource will be called on the master node for the class, and it always returns null. The error will be cached by the underlying class loader and it fails for all the later calls on the same RemoteClassLoader, without loading the class anymore.
      * If the cache finishes before the loading, everything works fine.
