### PR TITLE
Certificate authentication for Azure Service Principal

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,64 @@
 # Azure Credentials plugin
 
-Jenkins Plugin to manage Azure Service Principal credentials.
+Jenkins plugin to manage Azure credentials.
 
-* [Bash Script for creating a service principal](https://github.com/Azure/azure-devops-utils/blob/master/bash/create-service-principal.sh)
 * [General information on how to use credentials in Jenkins](https://wiki.jenkins-ci.org/display/JENKINS/Credentials+Plugin)
 
-#### Using existing credentials to login to Azure using the Java Azure SDK
+It supports the following Azure credential types:
+
+1. [Azure Service Principal](https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-create-service-principal-portal),
+   with the following authentication mechanism:
+   * Client secret
+   * Certificate (Add the certificate to Jenkins credentials store and reference it in the Azure Service Principal
+      configuration)
+1. [Azure Managed Service Identity (MSI)](https://docs.microsoft.com/en-us/azure/active-directory/msi-overview)
+1. [Credentials In Azure Key Vault](https://docs.microsoft.com/en-us/azure/key-vault/key-vault-get-started)
+
+## Using existing credentials to login to Azure using the Java Azure SDK
+
+1. Update your project POM file to reference `azure-credentials` plugin and necessary dependencies:
+
+   ```xml
+   ...
+   <dependencies>
+      <dependency>
+          <groupId>org.jenkins-ci.plugins</groupId>
+          <artifactId>azure-credentials</artifactId>
+          <version>${azure-credentials.version}</version>
+      </dependency>
+      <dependency>
+          <groupId>org.jenkins-ci.plugins</groupId>
+          <artifactId>azure-commons-core</artifactId>
+          <version>${azure-commons.version}</version>
+      </dependency>
+      ...
+   </dependencies>
+   <build>
+      <plugins>
+          <plugin>
+              <groupId>org.jenkins-ci.tools</groupId>
+              <artifactId>maven-hpi-plugin</artifactId>
+              <configuration>
+                  <maskClasses>
+                      com.microsoft.jenkins.azurecommons.core.
+                  </maskClasses>
+               </configuration>
+          </plugin>
+       </plugins>
+       ...
+   </build>
+   ```
+1. Build the Azure client from the credential
+
+   ```Java
+   AzureBaseCredentials credential = AzureCredentialUtil.getCredential2(credentialsId);
+   // Resolve the class loader incompatibility issue. Works along with maskClasses in the POM
+   TokenCredentialData token = TokenCredentialData.deserialize(credential.serializeToTokenData());
+   Azure azClient = AzureClientFactory.getClient(token);
+   ```
+
+## Getting an iterator to all SYSTEM owned Azure Credentials
 
 ```Java
-ServicePrincipal servicePrincipal = AzureCredentials.getServicePrincipal("<credentials_id>");
-Azure azClient = Azure.authenticate(new ApplicationTokenCredentials(
-                servicePrincipal.getClientId(),
-                servicePrincipal.getTenant(),
-                servicePrincipal.getClientSecret(),
-                servicePrincipal.getAzureEnvironment()));
-```
-
-#### Getting an iterator to all SYSTEM owned Azure Credentials
-```Java
-CredentialsProvider.lookupCredentials(AzureCredentials.class, null, ACL.SYSTEM, Collections.<DomainRequirement>emptyList()
+CredentialsProvider.lookupCredentials(AzureBaseCredentials.class, null, ACL.SYSTEM, Collections.<DomainRequirement>emptyList());
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
@@ -32,8 +33,9 @@
         <jenkins.version>1.625.3</jenkins.version>
         <java.level>7</java.level>
         <jenkins-test-harness.version>2.13</jenkins-test-harness.version>
-        
+
         <azuresdk.version>1.3.0</azuresdk.version>
+        <azure-commons.version>0.2.4</azure-commons.version>
         <azure-keyvault.version>1.0.0</azure-keyvault.version>
     </properties>
 
@@ -48,7 +50,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>azure-commons-core</artifactId>
-            <version>0.2.0</version>
+            <version>${azure-commons.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -69,17 +71,6 @@
             <groupId>com.microsoft.azure</groupId>
             <artifactId>azure-keyvault</artifactId>
             <version>${azure-keyvault.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.main</groupId>
-            <artifactId>jenkins-core</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.google.guava</groupId>
-                    <artifactId>guava</artifactId>
-                </exclusion>
-            </exclusions>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
@@ -138,9 +129,36 @@
                 <groupId>org.jenkins-ci.tools</groupId>
                 <artifactId>maven-hpi-plugin</artifactId>
                 <configuration>
+                    <!--
+                    Mask all the Azure SDK related classes so that it will not affected by the SDK change in the
+                    depended plugins, such as azure-commons.
+                    -->
                     <maskClasses>
                         com.google.common.
                         com.microsoft.jenkins.azurecommons.core.
+
+                        com.microsoft.azure.AzureAsyncOperation
+                        com.microsoft.azure.AzureClient
+                        com.microsoft.azure.AzureEnvironment
+                        com.microsoft.azure.AzureResponseBuilder
+                        com.microsoft.azure.AzureServiceClient
+                        com.microsoft.azure.AzureServiceFuture
+                        com.microsoft.azure.CloudError
+                        com.microsoft.azure.CloudException
+                        com.microsoft.azure.ListOperationCallback
+                        com.microsoft.azure.Page
+                        com.microsoft.azure.PagedList
+                        com.microsoft.azure.PollingState
+                        com.microsoft.azure.Resource
+                        com.microsoft.azure.SubResource
+                        com.microsoft.aad.
+                        com.microsoft.applicationinsights.
+                        com.microsoft.azure.credentials.
+                        com.microsoft.azure.keyvault.
+                        com.microsoft.azure.management.
+                        com.microsoft.azure.serializer.
+                        com.microsoft.azure.storage.
+                        com.microsoft.rest.
                     </maskClasses>
                 </configuration>
             </plugin>

--- a/src/main/java/com/microsoft/azure/util/AzureCredentials.java
+++ b/src/main/java/com/microsoft/azure/util/AzureCredentials.java
@@ -7,24 +7,29 @@ package com.microsoft.azure.util;
 import com.cloudbees.plugins.credentials.CredentialsMatchers;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
 import com.cloudbees.plugins.credentials.domains.DomainRequirement;
 import com.cloudbees.plugins.credentials.impl.BaseStandardCredentials;
+import com.cloudbees.plugins.credentials.impl.CertificateCredentialsImpl;
 import com.microsoft.azure.AzureEnvironment;
 import com.microsoft.azure.credentials.ApplicationTokenCredentials;
 import com.microsoft.azure.management.Azure;
 import com.microsoft.azure.management.resources.Subscription;
 import com.microsoft.jenkins.azurecommons.core.credentials.TokenCredentialData;
 import hudson.Extension;
+import hudson.model.Item;
 import hudson.security.ACL;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import hudson.util.Secret;
 import jenkins.model.Jenkins;
 import org.apache.commons.lang.StringUtils;
+import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 
+import javax.annotation.Nullable;
 import java.io.ObjectStreamException;
 import java.util.Collections;
 import java.util.HashMap;
@@ -44,6 +49,11 @@ public class AzureCredentials extends AzureBaseCredentials {
         private final Secret subscriptionId;
         private final Secret clientId;
         private final Secret clientSecret;
+        /**
+         * The ID of the PKCS#12 certificate stored in Jenkins master.
+         * Used for authentication if {@link #clientSecret} is not provided.
+         */
+        private String certificateId;
         private Secret oauth2TokenEndpoint; //keeping this for backwards compatibility
         private String serviceManagementURL;
         private Secret tenant;
@@ -132,6 +142,65 @@ public class AzureCredentials extends AzureBaseCredentials {
             } else {
                 return clientSecret.getPlainText();
             }
+        }
+
+        public String getCertificateId() {
+            return certificateId;
+        }
+
+        public void setCertificateId(String certificateId) {
+            this.certificateId = certificateId;
+        }
+
+        /**
+         * Get the certificate configured in the Service Principal.
+         * <p>
+         * Return <code>null</code> if:
+         * <ul>
+         * <li><code>clientSecret</code> is not empty. <code>clientSecret</code> will be used if not empty.</li>
+         * <li><code>certificateId</code> is empty or the given certificate is not found.</li>
+         * </ul>
+         * <p>
+         * Note: Azure {@link ApplicationTokenCredentials} requires the raw bytes of the whole certificate, rather than
+         * the key(s) returned from the KeyStore. We need to return {@link CertificateCredentialsImpl} which has the
+         * <code>getKeyStoreSource()</code> method that returns the raw certificate.
+         *
+         * @return the certificate configured in the Service Principal.
+         */
+        @Nullable
+        public CertificateCredentialsImpl getCertificate() {
+            if (StringUtils.isNotEmpty(clientSecret.getPlainText())) {
+                return null;
+            }
+            if (StringUtils.isEmpty(certificateId)) {
+                return null;
+            }
+            CertificateCredentialsImpl certificate = CredentialsMatchers.firstOrNull(
+                    CredentialsProvider.lookupCredentials(
+                            CertificateCredentialsImpl.class,
+                            Jenkins.getInstance(),
+                            ACL.SYSTEM,
+                            Collections.<DomainRequirement>emptyList()),
+                    CredentialsMatchers.withId(certificateId));
+            return certificate;
+        }
+
+        @Nullable
+        public byte[] getCertificateBytes() {
+            CertificateCredentialsImpl certificate = getCertificate();
+            if (certificate == null) {
+                return null;
+            }
+            return certificate.getKeyStoreSource().getKeyStoreBytes();
+        }
+
+        @Nullable
+        public String getCertificatePassword() {
+            CertificateCredentialsImpl certificate = getCertificate();
+            if (certificate == null) {
+                return null;
+            }
+            return certificate.getPassword().getPlainText();
         }
 
         public String getTenant() {
@@ -312,7 +381,8 @@ public class AzureCredentials extends AzureBaseCredentials {
             if (StringUtils.isBlank(clientId.getPlainText())) {
                 throw new ValidationException(Messages.Azure_ClientID_Missing());
             }
-            if (StringUtils.isBlank(clientSecret.getPlainText())) {
+            String secret = clientSecret.getPlainText();
+            if (StringUtils.isEmpty(secret) && StringUtils.isBlank(certificateId)) {
                 throw new ValidationException(Messages.Azure_ClientSecret_Missing());
             }
             if (StringUtils.isBlank(getTenant())) {
@@ -321,12 +391,30 @@ public class AzureCredentials extends AzureBaseCredentials {
 
             try {
                 final String credentialSubscriptionId = getSubscriptionId();
-                Azure.Authenticated auth = Azure.authenticate(
-                        new ApplicationTokenCredentials(
-                                getClientId(),
-                                getTenant(),
-                                getClientSecret(),
-                                getAzureEnvironment()));
+
+                Azure.Authenticated auth;
+
+                if (StringUtils.isEmpty(secret)) {
+                    CertificateCredentialsImpl certificate = getCertificate();
+                    if (certificate == null) {
+                        throw new ValidationException(Messages.Azure_ClientCertificate_NotFound());
+                    }
+                    byte[] certificateBytes = certificate.getKeyStoreSource().getKeyStoreBytes();
+                    auth = Azure.authenticate(
+                            new ApplicationTokenCredentials(
+                                    getClientId(),
+                                    getTenant(),
+                                    certificateBytes,
+                                    certificate.getPassword().getPlainText(),
+                                    getAzureEnvironment()));
+                } else {
+                    auth = Azure.authenticate(
+                            new ApplicationTokenCredentials(
+                                    getClientId(),
+                                    getTenant(),
+                                    getClientSecret(),
+                                    getAzureEnvironment()));
+                }
                 for (Subscription subscription : auth.subscriptions().list()) {
                     if (subscription.subscriptionId().equalsIgnoreCase(credentialSubscriptionId)) {
                         return true;
@@ -419,11 +507,23 @@ public class AzureCredentials extends AzureBaseCredentials {
     }
 
     public String getClientSecret() {
+        if (StringUtils.isEmpty(data.clientSecret.getPlainText())) {
+            return "";
+        }
         return data.clientSecret.getEncryptedValue();
     }
 
     public String getPlainClientSecret() {
         return data.clientSecret.getPlainText();
+    }
+
+    @DataBoundSetter
+    public void setCertificateId(String certificateId) {
+        this.data.setCertificateId(certificateId);
+    }
+
+    public String getCertificateId() {
+        return data.getCertificateId();
     }
 
     public String getTenant() {
@@ -577,6 +677,7 @@ public class AzureCredentials extends AzureBaseCredentials {
                 @QueryParameter String subscriptionId,
                 @QueryParameter String clientId,
                 @QueryParameter String clientSecret,
+                @QueryParameter String certificateId,
                 @QueryParameter String tenant,
                 @QueryParameter String serviceManagementURL,
                 @QueryParameter String authenticationEndpoint,
@@ -585,6 +686,7 @@ public class AzureCredentials extends AzureBaseCredentials {
 
             AzureCredentials.ServicePrincipal servicePrincipal
                     = new AzureCredentials.ServicePrincipal(subscriptionId, clientId, clientSecret);
+            servicePrincipal.setCertificateId(certificateId);
             servicePrincipal.setTenant(tenant);
             servicePrincipal.setManagementEndpoint(serviceManagementURL);
             servicePrincipal.setActiveDirectoryEndpoint(authenticationEndpoint);
@@ -597,6 +699,13 @@ public class AzureCredentials extends AzureBaseCredentials {
             }
 
             return FormValidation.ok(Messages.Azure_Config_Success());
+        }
+
+        public ListBoxModel doFillCertificateIdItems(@AncestorInPath Item owner) {
+            StandardListBoxModel model = new StandardListBoxModel();
+            model.add(Messages.Azure_Credentials_Select(), "");
+            model.includeAs(ACL.SYSTEM, owner, CertificateCredentialsImpl.class);
+            return model;
         }
 
         public ListBoxModel doFillAzureEnvironmentNameItems() {

--- a/src/main/java/com/microsoft/azure/util/AzureCredentials.java
+++ b/src/main/java/com/microsoft/azure/util/AzureCredentials.java
@@ -168,7 +168,7 @@ public class AzureCredentials extends AzureBaseCredentials {
          * @return the certificate configured in the Service Principal.
          */
         @Nullable
-        public CertificateCredentialsImpl getCertificate() {
+        CertificateCredentialsImpl getCertificate() {
             if (StringUtils.isNotEmpty(clientSecret.getPlainText())) {
                 return null;
             }
@@ -650,6 +650,8 @@ public class AzureCredentials extends AzureBaseCredentials {
         token.setType(TokenCredentialData.TYPE_SP);
         token.setClientId(getClientId());
         token.setClientSecret(getPlainClientSecret());
+        token.setCertificateBytes(data.getCertificateBytes());
+        token.setCertificatePassword(data.getCertificatePassword());
         token.setTenant(getTenant());
         token.setSubscriptionId(getSubscriptionId());
         return token;

--- a/src/main/resources/com/microsoft/azure/util/AzureCredentials/credentials.jelly
+++ b/src/main/resources/com/microsoft/azure/util/AzureCredentials/credentials.jelly
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler">
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler" xmlns:c="/lib/credentials">
     <j:set var="uniqueId" value="${h.generateId()}"/>
     <f:entry title="${%SubscriptionID}" field="subscriptionId"
              help="/plugin/azure-credentials/help-subscriptionId.html">
@@ -11,6 +11,9 @@
     </f:entry>
     <f:entry title="${%ClientSecret}" field="clientSecret" help="/plugin/azure-credentials/help-clientSecret.html">
         <f:password/>
+    </f:entry>
+    <f:entry title="${%CertificateId}" field="certificateId" help="/plugin/azure-credentials/help-certificateId.html">
+        <c:select expressionAllowed="false" />
     </f:entry>
     <f:entry title="${%Tenant}" field="tenant" help="/plugin/azure-credentials/help-tenant.html">
         <f:textbox/>
@@ -41,6 +44,6 @@
 
     <st:include page="id-and-description" class="${descriptor.clazz}"/>
     <f:validateButton title="${%VerifyConfiguration}" progress="${%VerifyingMsg}" method="verifyConfiguration"
-                      with="subscriptionId,clientId,clientSecret,tenant,serviceManagementURL,authenticationEndpoint,resourceManagerEndpoint,graphEndpoint"/>
+                      with="subscriptionId,clientId,clientSecret,certificateId,tenant,serviceManagementURL,authenticationEndpoint,resourceManagerEndpoint,graphEndpoint"/>
 </j:jelly>
 

--- a/src/main/resources/com/microsoft/azure/util/AzureCredentials/credentials.properties
+++ b/src/main/resources/com/microsoft/azure/util/AzureCredentials/credentials.properties
@@ -1,6 +1,7 @@
 SubscriptionID=Subscription ID
 ClientID=Client ID
 ClientSecret=Client Secret
+CertificateId=Or, Certificate
 Tenant=Tenant ID
 AzureEnvironmentName=Azure Environment
 ManagementServiceURL=Override Management Endpoint

--- a/src/main/resources/com/microsoft/azure/util/Messages.properties
+++ b/src/main/resources/com/microsoft/azure/util/Messages.properties
@@ -1,13 +1,14 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See LICENSE file in the project root for license information.
 
-// CHECKSTYLE:OFF
 Azure_Config_Success=Successfully verified the Microsoft Azure Service Principal.
 Azure_CantValidate=The provided credentials are not valid
 Azure_Invalid_SubscriptionId=The subscription id is not valid
 Azure_SubscriptionID_Missing=Error: Subscription ID is missing.
 Azure_ClientID_Missing=Error: Client ID is missing.
-Azure_ClientSecret_Missing=Error: Client Secret is missing.
+Azure_ClientSecret_Missing=Error: Neither Client Secret nor Certificate is provided.
+Azure_ClientCertificate_NotFound=Error: The selected Certificate was not found.
+Azure_Credentials_Select=--- Select a Certificate ---
 Azure_OAuthToken_Missing=Error: OAuth 2.0 Token Endpoint is missing.
 Azure_OAuthToken_Malformed=Error: OAuth 2.0 Token Endpoint is malformed.
 Azure_Credentials_Binding_Diaplay_Name=Microsoft Azure Service Principal

--- a/src/main/webapp/help-certificateId.html
+++ b/src/main/webapp/help-certificateId.html
@@ -1,0 +1,12 @@
+<!--
+  ~ Copyright (c) Microsoft Corporation. All rights reserved.
+  ~ Licensed under the MIT License. See LICENSE file in the project root for license information.
+  -->
+
+<div>
+    Select the PKCS#12 certificate used to authenticate with the service principal.<br/>
+    You can add a <i>Certificate</i> to the Jenkins Credentials store and it will show up in the list.
+    <p>
+    <b>Note</b>: The certificate will be used only when the <i>Client Secret</i> is not provided.
+    </p>
+</div>


### PR DESCRIPTION
Allow the service principal to be configured with a certificate (ID), which will be used when the `clientSecret` is empty.

To pick up the certificate authentication, the plugins using `azure-credentials` needs to add custom logic to authenticate with the `certificateBytes` and `certificatePassword` returned from the selected credential. Probably this should be moved to the `azure-commons-core` jar.