### PR TITLE
Use scoped credentials look up

### DIFF
--- a/src/main/java/com/microsoft/azure/util/AzureCredentialUtil.java
+++ b/src/main/java/com/microsoft/azure/util/AzureCredentialUtil.java
@@ -4,9 +4,11 @@ import com.cloudbees.plugins.credentials.BaseCredentials;
 import com.cloudbees.plugins.credentials.CredentialsMatchers;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.domains.DomainRequirement;
+import hudson.model.Item;
 import hudson.security.ACL;
 import jenkins.model.Jenkins;
 
+import javax.annotation.Nullable;
 import java.util.Collections;
 
 public final class AzureCredentialUtil {
@@ -14,6 +16,28 @@ public final class AzureCredentialUtil {
 
     }
 
+    public static AzureBaseCredentials getCredential(@Nullable Item owner, String credentialId) {
+        return CredentialsMatchers.firstOrNull(
+                CredentialsProvider.lookupCredentials(
+                        AzureBaseCredentials.class,
+                        owner,
+                        ACL.SYSTEM,
+                        Collections.<DomainRequirement>emptyList()),
+                CredentialsMatchers.withId(credentialId));
+    }
+
+    public static String getManagementEndpoint(@Nullable Item owner, String credentialId) {
+        AzureBaseCredentials credential = getCredential(owner, credentialId);
+        if (credential != null) {
+            return credential.getManagementEndpoint();
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * @deprecated see {@link #getCredential(Item, String)}
+     */
     @Deprecated
     public static BaseCredentials getCredential(String credentialId) {
         BaseCredentials credential = CredentialsMatchers.firstOrNull(
@@ -37,22 +61,19 @@ public final class AzureCredentialUtil {
         }
     }
 
+    /**
+     * @deprecated see {@link #getCredential(Item, String)}
+     */
+    @Deprecated
     public static AzureBaseCredentials getCredential2(String credentialId) {
-        return CredentialsMatchers.firstOrNull(
-                CredentialsProvider.lookupCredentials(
-                        AzureBaseCredentials.class,
-                        Jenkins.getInstance(),
-                        ACL.SYSTEM,
-                        Collections.<DomainRequirement>emptyList()),
-                CredentialsMatchers.withId(credentialId));
+        return getCredential(null, credentialId);
     }
 
+    /**
+     * @deprecated see {@link #getManagementEndpoint(Item, String)}
+     */
+    @Deprecated
     public static String getManagementEndpoint(String credentialId) {
-        AzureBaseCredentials credential = getCredential2(credentialId);
-        if (credential != null) {
-            return credential.getManagementEndpoint();
-        } else {
-            return null;
-        }
+        return getManagementEndpoint(null, credentialId);
     }
 }


### PR DESCRIPTION
Currently we passed the `Jenkins.instance()` to the credentials lookup method, which searches in the global credentials scope. However, in real world projects, the users may use the [cloudbees-folder](https://plugins.jenkins.io/cloudbees-folder) plugin to organize their projects in hierarchy, and restrict the credentials look up in different folders.

This is a fix to https://github.com/jenkinsci/azure-credentials-plugin/issues/25 .

This change added support for the scoped Azure credentials look up, and deprecated the original non-scoped ones. Further changes are needed for all the dependent plugins if necessary.

See also:
https://github.com/jenkinsci/kubernetes-cd-plugin/issues/19