### PR TITLE
Downgrade java level to 7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 
     <properties>
         <jenkins.version>1.625.3</jenkins.version>
-        <java.level>8</java.level>
+        <java.level>7</java.level>
         <jenkins-test-harness.version>2.13</jenkins-test-harness.version>
 
         <azuresdk.version>1.19.0</azuresdk.version>


### PR DESCRIPTION
Java level has been upgraded to 8 in PR #29 which is unnecessary. This change will affect other plugins depending on this one. Downgrade the java version to decrease the risk of the current release.