### PR TITLE
Use Azure container instances for building

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,4 +2,4 @@
 
 
 /* `buildPlugin` step provided by: https://github.com/jenkins-infra/pipeline-library */
-buildPlugin()
+buildPlugin(useAci: true)


### PR DESCRIPTION
They spin up more reliably than the vm agents, currently there's no linux VMs available and I've been waiting 6 hours

cc @xuzhang3 