### PR TITLE
JENKINS-62011 Revert breaking changes

### DIFF
--- a/src/main/java/com/microsoft/azure/util/AzureCredentials.java
+++ b/src/main/java/com/microsoft/azure/util/AzureCredentials.java
@@ -223,13 +223,6 @@ public class AzureCredentials extends AzureBaseCredentials {
             }
         }
 
-        public String getEncryptTenant() {
-            if (tenant == null || StringUtils.isBlank(tenant.getPlainText())) {
-                return "";
-            }
-            return tenant.getEncryptedValue();
-        }
-
         public String getAzureEnvironmentName() {
             return azureEnvironmentName;
         }
@@ -555,24 +548,10 @@ public class AzureCredentials extends AzureBaseCredentials {
     }
 
     public String getSubscriptionId() {
-        if (StringUtils.isEmpty(data.subscriptionId.getPlainText())) {
-            return "";
-        }
-        return data.subscriptionId.getEncryptedValue();
-    }
-
-    public String getPlainSubscriptionId() {
         return data.subscriptionId.getPlainText();
     }
 
     public String getClientId() {
-        if (StringUtils.isEmpty(data.clientId.getPlainText())) {
-            return "";
-        }
-        return data.clientId.getEncryptedValue();
-    }
-
-    public String getPlainClientId() {
         return data.clientId.getPlainText();
     }
 
@@ -597,10 +576,6 @@ public class AzureCredentials extends AzureBaseCredentials {
     }
 
     public String getTenant() {
-        return data.getEncryptTenant();
-    }
-
-    public String getPlainTenant() {
         return data.getTenant();
     }
 
@@ -722,12 +697,12 @@ public class AzureCredentials extends AzureBaseCredentials {
     public TokenCredentialData createToken() {
         TokenCredentialData token = super.createToken();
         token.setType(TokenCredentialData.TYPE_SP);
-        token.setClientId(getPlainClientId());
+        token.setClientId(getClientId());
         token.setClientSecret(getPlainClientSecret());
         token.setCertificateBytes(data.getCertificateBytes());
         token.setCertificatePassword(data.getCertificatePassword());
-        token.setTenant(getPlainTenant());
-        token.setSubscriptionId(getPlainSubscriptionId());
+        token.setTenant(getTenant());
+        token.setSubscriptionId(getSubscriptionId());
         return token;
     }
 

--- a/src/main/java/com/microsoft/azure/util/AzureCredentials.java
+++ b/src/main/java/com/microsoft/azure/util/AzureCredentials.java
@@ -223,6 +223,13 @@ public class AzureCredentials extends AzureBaseCredentials {
             }
         }
 
+        public String getEncryptTenant() {
+            if (tenant == null || StringUtils.isBlank(tenant.getPlainText())) {
+                return "";
+            }
+            return tenant.getEncryptedValue();
+        }
+
         public String getAzureEnvironmentName() {
             return azureEnvironmentName;
         }
@@ -548,10 +555,24 @@ public class AzureCredentials extends AzureBaseCredentials {
     }
 
     public String getSubscriptionId() {
+        if (StringUtils.isEmpty(data.subscriptionId.getPlainText())) {
+            return "";
+        }
+        return data.subscriptionId.getEncryptedValue();
+    }
+
+    public String getPlainSubscriptionId() {
         return data.subscriptionId.getPlainText();
     }
 
     public String getClientId() {
+        if (StringUtils.isEmpty(data.clientId.getPlainText())) {
+            return "";
+        }
+        return data.clientId.getEncryptedValue();
+    }
+
+    public String getPlainClientId() {
         return data.clientId.getPlainText();
     }
 
@@ -576,6 +597,10 @@ public class AzureCredentials extends AzureBaseCredentials {
     }
 
     public String getTenant() {
+        return data.getEncryptTenant();
+    }
+
+    public String getPlainTenant() {
         return data.getTenant();
     }
 
@@ -697,12 +722,12 @@ public class AzureCredentials extends AzureBaseCredentials {
     public TokenCredentialData createToken() {
         TokenCredentialData token = super.createToken();
         token.setType(TokenCredentialData.TYPE_SP);
-        token.setClientId(getClientId());
+        token.setClientId(getPlainClientId());
         token.setClientSecret(getPlainClientSecret());
         token.setCertificateBytes(data.getCertificateBytes());
         token.setCertificatePassword(data.getCertificatePassword());
-        token.setTenant(getTenant());
-        token.setSubscriptionId(getSubscriptionId());
+        token.setTenant(getPlainTenant());
+        token.setSubscriptionId(getPlainSubscriptionId());
         return token;
     }
 

--- a/src/main/java/com/microsoft/azure/util/AzureCredentialsBinding.java
+++ b/src/main/java/com/microsoft/azure/util/AzureCredentialsBinding.java
@@ -132,10 +132,10 @@ public class AzureCredentialsBinding extends MultiBinding<AzureCredentials> {
             throws IOException, InterruptedException {
         AzureCredentials credentials = getCredentials(build);
         Map<String, String> map = new HashMap<>();
-        map.put(getSubscriptionIdVariable(), credentials.getSubscriptionId().getPlainText());
-        map.put(getClientIdVariable(), credentials.getClientId().getPlainText());
+        map.put(getSubscriptionIdVariable(), credentials.getSubscriptionId());
+        map.put(getClientIdVariable(), credentials.getClientId());
         map.put(getClientSecretVariable(), credentials.getPlainClientSecret());
-        map.put(getTenantIdVariable(), credentials.getPlainTenant());
+        map.put(getTenantIdVariable(), credentials.getTenant());
         return new MultiEnvironment(map);
     }
 

--- a/src/main/java/com/microsoft/azure/util/AzureCredentialsBinding.java
+++ b/src/main/java/com/microsoft/azure/util/AzureCredentialsBinding.java
@@ -132,10 +132,10 @@ public class AzureCredentialsBinding extends MultiBinding<AzureCredentials> {
             throws IOException, InterruptedException {
         AzureCredentials credentials = getCredentials(build);
         Map<String, String> map = new HashMap<>();
-        map.put(getSubscriptionIdVariable(), credentials.getSubscriptionId());
-        map.put(getClientIdVariable(), credentials.getClientId());
+        map.put(getSubscriptionIdVariable(), credentials.getPlainSubscriptionId());
+        map.put(getClientIdVariable(), credentials.getPlainClientId());
         map.put(getClientSecretVariable(), credentials.getPlainClientSecret());
-        map.put(getTenantIdVariable(), credentials.getTenant());
+        map.put(getTenantIdVariable(), credentials.getPlainTenant());
         return new MultiEnvironment(map);
     }
 

--- a/src/main/java/com/microsoft/azure/util/AzureCredentialsBinding.java
+++ b/src/main/java/com/microsoft/azure/util/AzureCredentialsBinding.java
@@ -132,10 +132,10 @@ public class AzureCredentialsBinding extends MultiBinding<AzureCredentials> {
             throws IOException, InterruptedException {
         AzureCredentials credentials = getCredentials(build);
         Map<String, String> map = new HashMap<>();
-        map.put(getSubscriptionIdVariable(), credentials.getPlainSubscriptionId());
-        map.put(getClientIdVariable(), credentials.getPlainClientId());
+        map.put(getSubscriptionIdVariable(), credentials.getSubscriptionId());
+        map.put(getClientIdVariable(), credentials.getClientId());
         map.put(getClientSecretVariable(), credentials.getPlainClientSecret());
-        map.put(getTenantIdVariable(), credentials.getPlainTenant());
+        map.put(getTenantIdVariable(), credentials.getTenant());
         return new MultiEnvironment(map);
     }
 

--- a/src/main/resources/com/microsoft/azure/util/AzureCredentials/credentials.jelly
+++ b/src/main/resources/com/microsoft/azure/util/AzureCredentials/credentials.jelly
@@ -4,10 +4,10 @@
     <j:set var="uniqueId" value="${h.generateId()}"/>
     <f:entry title="${%SubscriptionID}" field="subscriptionId"
              help="/plugin/azure-credentials/help-subscriptionId.html">
-        <f:password/>
+        <f:textbox/>
     </f:entry>
     <f:entry title="${%ClientID}" field="clientId" help="/plugin/azure-credentials/help-clientId.html">
-        <f:password/>
+        <f:textbox/>
     </f:entry>
     <f:entry title="${%ClientSecret}" field="clientSecret" help="/plugin/azure-credentials/help-clientSecret.html">
         <f:password/>
@@ -16,7 +16,7 @@
         <c:select expressionAllowed="false" />
     </f:entry>
     <f:entry title="${%Tenant}" field="tenant" help="/plugin/azure-credentials/help-tenant.html">
-        <f:password/>
+        <f:textbox/>
     </f:entry>
     <f:entry title="${%AzureEnvironmentName}" field="azureEnvironmentName"
              help="/plugin/azure-credentials/help-azureEnvironmentName.html">

--- a/src/main/resources/com/microsoft/azure/util/AzureCredentials/credentials.jelly
+++ b/src/main/resources/com/microsoft/azure/util/AzureCredentials/credentials.jelly
@@ -4,10 +4,10 @@
     <j:set var="uniqueId" value="${h.generateId()}"/>
     <f:entry title="${%SubscriptionID}" field="subscriptionId"
              help="/plugin/azure-credentials/help-subscriptionId.html">
-        <f:textbox/>
+        <f:password/>
     </f:entry>
     <f:entry title="${%ClientID}" field="clientId" help="/plugin/azure-credentials/help-clientId.html">
-        <f:textbox/>
+        <f:password/>
     </f:entry>
     <f:entry title="${%ClientSecret}" field="clientSecret" help="/plugin/azure-credentials/help-clientSecret.html">
         <f:password/>
@@ -16,7 +16,7 @@
         <c:select expressionAllowed="false" />
     </f:entry>
     <f:entry title="${%Tenant}" field="tenant" help="/plugin/azure-credentials/help-tenant.html">
-        <f:textbox/>
+        <f:password/>
     </f:entry>
     <f:entry title="${%AzureEnvironmentName}" field="azureEnvironmentName"
              help="/plugin/azure-credentials/help-azureEnvironmentName.html">

--- a/src/test/java/com/microsoft/jenkins/keyvault/integration/KeyVaultIntegrationTestBase.java
+++ b/src/test/java/com/microsoft/jenkins/keyvault/integration/KeyVaultIntegrationTestBase.java
@@ -20,8 +20,6 @@ import com.microsoft.jenkins.integration.IntegrationTestBase;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
-
-import hudson.util.Secret;
 import org.junit.Assert;
 import org.junit.Before;
 
@@ -55,8 +53,8 @@ public abstract class KeyVaultIntegrationTestBase extends IntegrationTestBase {
                 CredentialsScope.SYSTEM,
                 jenkinsAzureCredentialsId,
                 "",
-                Secret.fromString(testEnv.subscriptionId),
-                Secret.fromString(testEnv.clientId),
+                testEnv.subscriptionId,
+                testEnv.clientId,
                 testEnv.clientSecret);
         credentials.setOauth2TokenEndpoint("http://host/" + testEnv.tenantId + "/oauth2");
 


### PR DESCRIPTION
I disagree with the previous change, it has caused widespread breakage in the Azure Jenkins ecosystem, pretty much every plugin that touched Azure is broken.

Releasing a plugin as a major version isn't really a fix but at least it means users might check the changelog, but there's nothing in the changelog to tell them the Azure eco system is broken 😢 

I know this was raised by someone as a security issue, but that doesn't mean they are correct, their reasoning was that someone had blocked the values out in a screenshot,

A number of counterpoints:

* Azure DevOps doesn't hide these values
* Every single URL that you pass in the portal has the subscription ID, (and the tenants display name)
* Many parts of the portal display all of those values in plain text
* you can look any of those values up in plain text
* `az account show` returns all those values in plain text

Please revert this unnecessary change

Three reasons:
1. it's broken pretty much every Azure plugin, this search has some places it's broken in but it hasn't found all places: https://github.com/search?p=1&q=org%3Ajenkinsci+getClientId&type=Code
2. it's absolutely not required as it's not treated in this sensitive way in Azure
3. These values are very useful for debugging, i.e. making sure the subscription ID isn't typoed

cc @xuzhang3 

cc @gavinfish (in case you want to weigh in as previous maintainer)

FYI in case you do keep this, you really need to mark it as incompatible, notes in the changelog and following this process: https://wiki.jenkins.io/display/JENKINS/Marking+a+new+plugin+version+as+incompatible+with+older+versions

i.e. set the `<hpi.compatibleSinceVersion>4.0</hpi.compatibleSinceVersion>` in the properties section of your pom.xml