### PR TITLE
use the proxy authentication only if a user is defined

### DIFF
--- a/src/main/java/com/microsoft/azure/util/AzureCredentials.java
+++ b/src/main/java/com/microsoft/azure/util/AzureCredentials.java
@@ -515,7 +515,9 @@ public class AzureCredentials extends AzureBaseCredentials {
         ProxyOptions proxyOptions = null;
         if (proxy != null) {
             proxyOptions = new ProxyOptions(ProxyOptions.Type.HTTP, new InetSocketAddress(proxy.name, proxy.port));
-            proxyOptions.setCredentials(proxy.getUserName(), proxy.getPassword());
+            if (proxy.getUserName() != null) {
+                proxyOptions.setCredentials(proxy.getUserName(), proxy.getPassword());
+            }
         }
         HttpClient httpClient = new NettyAsyncHttpClientBuilder().proxy(proxyOptions).build();
 


### PR DESCRIPTION
This is a follow up of https://github.com/jenkinsci/azure-credentials-plugin/pull/46. Right now, when a proxy without username + password is defined, the plugin fails, since `proxy.getUserName()` returns `null`. With this change, the plugin will only use the proxy credentials if the username is not null. For `proxy.getPassword()` it returns a empty string, so I do not see an issue there.