### PR TITLE
Remove Azure Germany from selection list

### DIFF
--- a/src/main/java/com/microsoft/azure/util/AzureCredentials.java
+++ b/src/main/java/com/microsoft/azure/util/AzureCredentials.java
@@ -810,7 +810,6 @@ public class AzureCredentials extends AzureBaseCredentials {
             ListBoxModel model = new ListBoxModel();
             model.add(AzureEnvUtil.Constants.ENV_AZURE);
             model.add(AzureEnvUtil.Constants.ENV_AZURE_CHINA);
-            model.add(AzureEnvUtil.Constants.ENV_AZURE_GERMANY);
             model.add(AzureEnvUtil.Constants.ENV_AZURE_US_GOVERNMENT);
             return model;
         }

--- a/src/main/java/com/microsoft/azure/util/AzureImdsCredentials.java
+++ b/src/main/java/com/microsoft/azure/util/AzureImdsCredentials.java
@@ -100,7 +100,6 @@ public class AzureImdsCredentials extends AbstractManagedIdentitiesCredentials {
             ListBoxModel model = new ListBoxModel();
             model.add(AzureEnvUtil.Constants.ENV_AZURE);
             model.add(AzureEnvUtil.Constants.ENV_AZURE_CHINA);
-            model.add(AzureEnvUtil.Constants.ENV_AZURE_GERMANY);
             model.add(AzureEnvUtil.Constants.ENV_AZURE_US_GOVERNMENT);
             return model;
         }

--- a/src/main/webapp/help-authenticationEndpoint.html
+++ b/src/main/webapp/help-authenticationEndpoint.html
@@ -5,7 +5,6 @@
     <ul>
         <li>Azure - https://login.microsoftonline.com/</li>
         <li>Azure China - https://login.chinacloudapi.cn/</li>
-        <li>Azure Germany - https://login.microsoftonline.de/</li>
         <li>Azure US Government - https://login-us.microsoftonline.com/</li>
     </ul>
 </div>


### PR DESCRIPTION
- Fixes #166.

Azure Germany was deprecated and removed from `knownEnvironments` in
- https://github.com/Azure/azure-sdk-for-java/pull/32505/files

At this moment login.microsoftonline.de (51.5.145.223) is in unreachable network.

Note: `portalUrl=portal.microsoftazure.de` set in `AZURE_GERMANY` is not known to DNSes at this moment.

-----

As I'm not familiar with `AzureEnvUtil` usage - only GERMANY from selection lists were removed, and kept in other places (that perhaps are used to deserialize should Azure Germany be used in already stored configuration).

-----

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

