### PR TITLE
Fix build warning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,6 @@
         <version>3.3.0</version>
         <configuration>
           <configLocation>checkstyle.xml</configLocation>
-          <encoding>UTF-8</encoding>
           <consoleOutput>true</consoleOutput>
           <resourceIncludes>src/main/resources/**</resourceIncludes>
         </configuration>


### PR DESCRIPTION
> [WARNING] Parameter 'encoding' is unknown for plugin 'maven-checkstyle-plugin:3.3.0:check (validate)'