### PR TITLE
Allow empty client to be returned when plugin is not configured

### DIFF
--- a/src/main/java/com/microsoft/jenkins/credentials/AzureResourceManagerCache.java
+++ b/src/main/java/com/microsoft/jenkins/credentials/AzureResourceManagerCache.java
@@ -18,6 +18,7 @@ package com.microsoft.jenkins.credentials;
 import com.azure.resourcemanager.AzureResourceManager;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import java.time.Duration;
 import java.util.Objects;
 
@@ -34,24 +35,14 @@ public final class AzureResourceManagerCache {
 
     private AzureResourceManagerCache() {}
 
+    @CheckForNull
     public static AzureResourceManager get(String credentialsId) {
-        AzureResourceManager resourceManager = CACHE.get(new CacheKey(credentialsId));
-        if (resourceManager == null) {
-            throw new RuntimeException(
-                    String.format("client null when it should not be, credentials ID: " + "%s", credentialsId));
-        }
-        return resourceManager;
+        return CACHE.get(new CacheKey(credentialsId));
     }
 
+    @CheckForNull
     public static AzureResourceManager get(String credentialsId, String subscriptionId) {
-        AzureResourceManager resourceManager = CACHE.get(new CacheKey(credentialsId, subscriptionId));
-
-        if (resourceManager == null) {
-            throw new RuntimeException(String.format(
-                    "client null when it should not be, credentials ID: " + "%s, subscriptionId: %s",
-                    credentialsId, subscriptionId));
-        }
-        return resourceManager;
+        return CACHE.get(new CacheKey(credentialsId, subscriptionId));
     }
 
     /**

--- a/src/main/java/com/microsoft/jenkins/credentials/AzureResourceManagerRetriever.java
+++ b/src/main/java/com/microsoft/jenkins/credentials/AzureResourceManagerRetriever.java
@@ -31,6 +31,9 @@ public final class AzureResourceManagerRetriever {
 
     public static AzureResourceManager getClient(String credentialId, @CheckForNull String subscriptionId) {
         AzureBaseCredentials credential = AzureCredentialUtil.getCredential(null, credentialId);
+        if (credential == null) {
+            return null;
+        }
 
         String actualSubscriptionId = subscriptionId != null ? subscriptionId : credential.getSubscriptionId();
         return getAzureResourceManager(credential, actualSubscriptionId);


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

Useful in the VM Agents plugin when in some cases the credential can be misconfigured and there's lots of log spam

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
